### PR TITLE
Use quote-props in a consistent way

### DIFF
--- a/rules/__fixtures__/core/quote-props.js
+++ b/rules/__fixtures__/core/quote-props.js
@@ -1,0 +1,20 @@
+module.exports = {
+  basic: {
+    foo: true,
+    bar: false,
+  },
+  redundant: {
+    foo: true,
+    'bar': false,
+    baz: null,
+  },
+  inconsistent: {
+    foo: true,
+    'bar baz': false,
+  },
+  numeric: {
+    '7411': true,
+    0x815: false,
+    42: null,
+  },
+};

--- a/rules/core.js
+++ b/rules/core.js
@@ -22,5 +22,8 @@ module.exports = {
     // project root to disable automatic git conversion for text files (example
     // file in this repo)
     'linebreak-style': ['error', 'unix'],
+
+    // enforce a unique quote style for object properties in a consistent way.
+    'quote-props': ['error', 'consistent-as-needed'],
   },
 };

--- a/rules/core.test.js
+++ b/rules/core.test.js
@@ -87,4 +87,37 @@ describe('core rules', () => {
       );
     });
   });
+
+  describe('quote-props', () => {
+    it('should warn', async () => {
+      const filePath = join(__dirname, '__fixtures__', 'core', 'quote-props.js');
+      const [{ messages, ...rest }] = await linter.lintFiles([filePath]);
+
+      expect(messages).toEqual([
+        expect.objectContaining({
+          line: 8,
+          messageId: 'redundantQuoting',
+          ruleId: 'quote-props',
+        }),
+        expect.objectContaining({
+          line: 12,
+          messageId: 'inconsistentlyQuotedProperty',
+          ruleId: 'quote-props',
+        }),
+        expect.objectContaining({
+          line: 16,
+          messageId: 'redundantQuoting',
+          ruleId: 'quote-props',
+        }),
+      ]);
+      expect(rest).toEqual(
+        expect.objectContaining({
+          errorCount: 3,
+          warningCount: 0,
+          fixableErrorCount: 3,
+          fixableWarningCount: 0,
+        }),
+      );
+    });
+  });
 });

--- a/rules/typescript-react.js
+++ b/rules/typescript-react.js
@@ -30,7 +30,7 @@ module.exports = {
             alwaysTryTypes: true,
           },
         },
-        react: {
+        'react': {
           pragma: 'React',
           version: 'detect',
         },


### PR DESCRIPTION
Enforce a unique quote style for object properties in a consistent way.

This closes [Issue 17: Quote props in a consistent way](https://github.com/edenspiekermann/espi-eslint-config/issues/17)