### PR TITLE
Feat/typescript no unused

### DIFF
--- a/rules/__fixtures__/typescript/no-unused-vars.ts
+++ b/rules/__fixtures__/typescript/no-unused-vars.ts
@@ -1,0 +1,6 @@
+export const calc: () => boolean = () => {
+  const unusedConst = true;
+  let unusedLet = true;
+  var unusedVar = true;
+  return true;
+};

--- a/rules/__fixtures__/typescript/no-use-before-define.ts
+++ b/rules/__fixtures__/typescript/no-use-before-define.ts
@@ -1,0 +1,5 @@
+export const x = Foo.FOO;
+
+enum Foo {
+  FOO,
+}

--- a/rules/typescript-react.js
+++ b/rules/typescript-react.js
@@ -3,20 +3,18 @@ const TypeScriptConfig = require('./typescript');
 module.exports = {
   overrides: [
     {
+      ...TypeScriptConfig.overrides[0],
+
       files: ['*.tsx'],
-      extends: [
-        'plugin:@typescript-eslint/recommended',
-        'plugin:@typescript-eslint/recommended-requiring-type-checking',
-      ],
-      parser: '@typescript-eslint/parser',
       parserOptions: {
-        project: './tsconfig.json',
+        ...TypeScriptConfig.overrides[0].parserOptions,
+
         ecmaFeatures: {
           jsx: true,
         },
       },
       plugins: [
-        '@typescript-eslint',
+        ...TypeScriptConfig.overrides[0].plugins,
       ],
       rules: {
         ...TypeScriptConfig.overrides[0].rules,
@@ -28,15 +26,9 @@ module.exports = {
         }],
       },
       settings: {
-        'import/parsers': {
-          '@typescript-eslint/parser': ['.tsx'],
-        },
-        'import/resolver': {
-          typescript: {
-            alwaysTryTypes: true,
-          },
-        },
-        'react': {
+        ...TypeScriptConfig.overrides[0].settings,
+
+        react: {
           pragma: 'React',
           version: 'detect',
         },

--- a/rules/typescript-react.js
+++ b/rules/typescript-react.js
@@ -1,3 +1,5 @@
+const TypeScriptConfig = require('./typescript');
+
 module.exports = {
   overrides: [
     {
@@ -17,6 +19,10 @@ module.exports = {
         '@typescript-eslint',
       ],
       rules: {
+        ...TypeScriptConfig.overrides[0].rules,
+
+        // Restrict file extensions that may contain JSX
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md
         'react/jsx-filename-extension': ['error', {
           extensions: ['.tsx'],
         }],

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -24,6 +24,18 @@ module.exports = {
         },
       },
       rules: {
+        // Enforce no unused vars: This rule extends the base "eslint/no-unused-vars"
+        // rule. It adds support for TypeScript features, such as types.
+        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md
+        '@typescript-eslint/no-unused-vars': 'error',
+        'no-unused-vars': 'off',
+
+        // Enforce no unused vars: This rule extends the base "eslint/no-use-before-define"
+        // rule. It adds support for type, interface and enum declarations.
+        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-use-before-define.md
+        '@typescript-eslint/no-use-before-define': 'error',
+        'no-use-before-define': 'off',
+
         // Enforce optional chaining if possible:
         // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-optional-chain.md
         '@typescript-eslint/prefer-optional-chain': ['error'],

--- a/rules/typescript.test.js
+++ b/rules/typescript.test.js
@@ -20,6 +20,67 @@ describe('typescript rules', () => {
     linter = null;
   });
 
+  describe('no-unused-vars', () => {
+    it('should error', async () => {
+      const filePath = join(__dirname, '__fixtures__', 'typescript', 'no-unused-vars.ts');
+      const [{ messages, ...rest }] = await linter.lintFiles([filePath]);
+
+      expect(messages).toEqual([
+        expect.objectContaining({
+          line: 2,
+          messageId: 'unusedVar',
+          ruleId: '@typescript-eslint/no-unused-vars',
+        }),
+        expect.objectContaining({
+          line: 3,
+          messageId: 'unusedVar',
+          ruleId: '@typescript-eslint/no-unused-vars',
+        }),
+        expect.any(Object),
+        expect.any(Object),
+        expect.objectContaining({
+          line: 4,
+          messageId: 'unusedVar',
+          ruleId: '@typescript-eslint/no-unused-vars',
+        }),
+      ]);
+
+      expect(rest).toEqual(
+        expect.objectContaining({
+          errorCount: 5,
+          warningCount: 0,
+          fixableErrorCount: 2,
+          fixableWarningCount: 0,
+        }),
+      );
+    });
+  });
+
+  describe('no-use-before-define', () => {
+    it('should error', async () => {
+      const filePath = join(__dirname, '__fixtures__', 'typescript', 'no-use-before-define.ts');
+      const [{ messages, ...rest }] = await linter.lintFiles([filePath]);
+
+      expect(messages).toEqual([
+        expect.objectContaining({
+          line: 1,
+          messageId: 'noUseBeforeDefine',
+          ruleId: '@typescript-eslint/no-use-before-define',
+        }),
+        expect.any(Object),
+      ]);
+
+      expect(rest).toEqual(
+        expect.objectContaining({
+          errorCount: 2,
+          warningCount: 0,
+          fixableErrorCount: 0,
+          fixableWarningCount: 0,
+        }),
+      );
+    });
+  });
+
   describe('prefer-optional-chain', () => {
     it('should error', async () => {
       const filePath = join(__dirname, '__fixtures__', 'typescript', 'prefer-optional-chain.ts');


### PR DESCRIPTION
Uses 

* `@typescript-eslint/no-unused-vars` instead of `no-unused-vars` for typescript
* `@typescript-eslint/no-use-before-define` instead of `no-use-before-define` for typescript
* typescript react inherits from typescript